### PR TITLE
bug fix for projections notebook

### DIFF
--- a/desihigh/projections.py
+++ b/desihigh/projections.py
@@ -149,14 +149,14 @@ def add_coordinate(latitude, longitude, rotate, zorder, coord='earth'):
         text_longitude_transform, text_latitude_transform = longitude, latitude-10
     else:
         text_longitude_transform, text_latitude_transform = rotate(longitude, latitude-10, lonlat=True)
-    long_label = plt.text(flip*np.deg2rad([text_longitude_transform]), np.deg2rad([text_latitude_transform]), text_longitude,color='cyan', weight='bold');
+    long_label = plt.text(flip*np.deg2rad(text_longitude_transform), np.deg2rad(text_latitude_transform), text_longitude,color='cyan', weight='bold');
     
     if rotate is None:
         text_longitude_transform, text_latitude_transform = longitude+10*flip, latitude
     else:
         text_longitude_transform, text_latitude_transform = rotate(longitude+10*flip, latitude, lonlat=True)
         
-    lat_label = plt.text(flip*np.deg2rad([text_longitude_transform]), np.deg2rad([text_latitude_transform]), text_latitude,color='magenta', weight='bold');
+    lat_label = plt.text(flip*np.deg2rad(text_longitude_transform), np.deg2rad(text_latitude_transform), text_latitude,color='magenta', weight='bold');
     
     long_label.set_path_effects([patheffects.Stroke(linewidth=3, foreground='black'),
                                  patheffects.Normal()])


### PR DESCRIPTION
Correction for the input data types for a call to matplotlib.pyplot.text. The old version worked offline but crashed on the Binder servers. I've verified that the new version of the code works with Binder.